### PR TITLE
Use vim.v.progpath to launch headless nvim

### DIFF
--- a/lua/lua-debug/init.lua
+++ b/lua/lua-debug/init.lua
@@ -72,7 +72,7 @@ function M.launch(opts)
     }
   end
 
-  nvim_server = vim.fn.jobstart({'nvim', '--embed', '--headless'}, {rpc = true})
+  nvim_server = vim.fn.jobstart({vim.v.progpath, '--embed', '--headless'}, {rpc = true})
   
   local hook_address = vim.fn.serverstart()
   vim.fn.rpcrequest(nvim_server, 'nvim_exec_lua', [[debug_hook_conn_address = ...]], {hook_address})

--- a/src/launch.lua.tl
+++ b/src/launch.lua.tl
@@ -15,7 +15,7 @@ end
 local nvim_server
 
 @spawn_nvim_instance_for_server+=
-nvim_server = vim.fn.jobstart({'nvim', '--embed', '--headless'}, {rpc = true})
+nvim_server = vim.fn.jobstart({vim.v.progpath, '--embed', '--headless'}, {rpc = true})
 
 @set_hook_instance_address+=
 local hook_address = vim.fn.serverstart()

--- a/src/test.lua.tl
+++ b/src/test.lua.tl
@@ -41,7 +41,7 @@ vim.wait(500)
 @close_debug_neovim_instance
 
 @create_debug_neovim_instance+=
-local debug_neovim_conn = vim.fn.jobstart({'nvim', '--embed', '--headless'}, {rpc = true})
+local debug_neovim_conn = vim.fn.jobstart({vim.v.progpath, '--embed', '--headless'}, {rpc = true})
 
 @close_debug_neovim_instance+=
 if debug_neovim_conn then


### PR DESCRIPTION
This makes it possible to use the debug adapter with a build from source
where the `build/bin/nvim` binary is directly invoked and the global
`nvim` within `$PATH` still points to a < 0.5 version.

(Btw, how are you running the tests and generating the sources from teal?)